### PR TITLE
FIX: connect derivative outputs

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -19,6 +19,7 @@ Participant Workflow
         hrf_model='',
         low_pass='',
         name='subtest',
+        output_dir='.',
         preproc_img_list=[''],
         selected_confounds=[''],
         smoothing_kernel=0.0)

--- a/src/nibetaseries/interfaces/bids.py
+++ b/src/nibetaseries/interfaces/bids.py
@@ -4,6 +4,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os
 import re
+from shutil import copy
 from nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, BaseInterfaceInputSpec,
     File, SimpleInterface
@@ -71,7 +72,7 @@ class DerivativesDataSink(SimpleInterface):
             base_directory = os.path.abspath(self.inputs.base_directory)
 
         out_path = '{}/{subject_id}'.format(self.out_path_base, **bids_dict)
-        if bids_dict['session_id'] is not None:
+        if bids_dict.get('session_id', None) is not None:
             out_path += '/{session_id}'.format(**bids_dict)
         out_path += '/{}'.format(mod)
 
@@ -88,6 +89,9 @@ class DerivativesDataSink(SimpleInterface):
             trialtype=betaseries_dict['trialtype_id'],
             suffix=self.inputs.suffix,
             ext=ext)
+
+        # copy the file to the output directory
+        copy(self.inputs.in_file, out_file)
 
         self._results['out_file'] = out_file
 

--- a/src/nibetaseries/interfaces/nilearn.py
+++ b/src/nibetaseries/interfaces/nilearn.py
@@ -56,7 +56,7 @@ class AtlasConnectivity(NilearnBaseInterface, SimpleInterface):
 
         # write out the file.
         out_file = os.path.join(runtime.cwd, 'fisher_z_correlation.tsv')
-        fisher_z_matrix_df.to_csv(out_file, sep='\t')
+        fisher_z_matrix_df.to_csv(out_file, sep='\t', na_rep='n/a')
 
         # save the filename in the outputs
         self._results['correlation_matrix'] = out_file


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Connects the output matrices from the [connectivity workflow](https://github.com/HBClab/NiBetaSeries/blob/master/src/nibetaseries/workflows/analysis.py#L17) to the [datasink](https://github.com/HBClab/NiBetaSeries/blob/master/src/nibetaseries/interfaces/bids.py#L38)
Fixes #21 

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- added `DerivativesDataSink` to `base.py`
- updated docs
- updated `DerivativesDataSink` interface