### PR TITLE
[FIX]: ignore sourcedata and derivatives directories in layout

### DIFF
--- a/src/nibetaseries/workflows/base.py
+++ b/src/nibetaseries/workflows/base.py
@@ -72,7 +72,7 @@ def init_nibetaseries_participant_wf(atlas_img, atlas_lut, bids_dir,
 
     # reading in derivatives and bids inputs as queryable database like objects
     derivatives_layout = BIDSLayout([(derivatives_pipeline_dir, ['bids', 'derivatives'])])
-    bids_layout = BIDSLayout(bids_dir)
+    bids_layout = BIDSLayout(bids_dir, exclude=['sourcedata', 'derivatives'])
 
     for subject_label in subject_list:
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Restricts the search space for pybids, which by default indexes everything.
Fixes #68. <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
- change the call to `layout` in `base.py`
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
