### PR TITLE
[FIX] confound removal

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -15,14 +15,13 @@ Participant Workflow
         brainmask_list=[''],
         confound_tsv_list=[''],
         events_tsv_list=[''],
-        high_pass='',
-        hrf_model='',
-        low_pass='',
+        hrf_model='glover',
+        low_pass=None,
         name='subtest',
         output_dir='.',
         preproc_img_list=[''],
         selected_confounds=[''],
-        smoothing_kernel=0.0)
+        smoothing_kernel=None)
 
 The general workflow for a participant models the betaseries for each trial type
 for each bold file associated with the participant.
@@ -43,7 +42,6 @@ BetaSeries Workflow
     wf = init_betaseries_wf(
         hrf_model='glover',
         low_pass=None,
-        high_pass=None,
         smoothing_kernel=0.0,
         selected_confounds=[''])
 

--- a/src/nibetaseries/cli/run.py
+++ b/src/nibetaseries/cli/run.py
@@ -46,9 +46,7 @@ def get_parser():
     proc_opts.add_argument('-sm', '--smoothing_kernel', action='store', type=float, default=6.0,
                            help='select a smoothing kernel (mm)')
     proc_opts.add_argument('-lp', '--low_pass', action='store', type=float,
-                           default=None, help='low pass filter')
-    proc_opts.add_argument('-hp', '--high_pass', action='store', type=float,
-                           default=None, help='high pass filter')
+                           default=None, help='low pass filter (Hz)')
     proc_opts.add_argument('-c', '--confounds', help='The confound column names '
                            'that are to be included in nuisance regression. '
                            'write the confounds you wish to include separated by a space',
@@ -156,7 +154,6 @@ def main():
             bids_dir=bids_dir,
             derivatives_pipeline_dir=derivatives_pipeline_dir,
             exclude_variant_label=opts.exclude_variant_label,
-            high_pass=opts.high_pass,
             hrf_model=opts.hrf_model,
             low_pass=opts.low_pass,
             output_dir=output_dir,

--- a/src/nibetaseries/interfaces/nistats.py
+++ b/src/nibetaseries/interfaces/nistats.py
@@ -27,7 +27,10 @@ class BetaSeriesInputSpec(BaseInterfaceInputSpec):
                           desc="File that contains all usable confounds")
     selected_confounds = traits.List(desc="Column names of the regressors to include")
     hrf_model = traits.String(desc="hemodynamic response model")
-    smoothing_kernel = traits.Float(desc="full wide half max smoothing kernel")
+    smoothing_kernel = traits.Either(None, traits.Float(),
+                                     desc="full wide half max smoothing kernel")
+    low_pass = traits.Either(None, traits.Float(),
+                             desc="the low pass filter (Hz)")
 
 
 class BetaSeriesOutputSpec(TraitedSpec):
@@ -50,14 +53,22 @@ class BetaSeries(NistatsBaseInterface, SimpleInterface):
         # get the confounds:
         confounds = _select_confounds(self.inputs.confounds_file,
                                       self.inputs.selected_confounds)
+        # low_pass, switch from Hz to Period
+        if self.inputs.low_pass:
+            low_pass_period = 1 / self.inputs.low_pass
+        else:
+            low_pass_period = None
+
         # setup the model
         model = first_level_model.FirstLevelModel(t_r=t_r,
                                                   slice_time_ref=0,
                                                   hrf_model=self.inputs.hrf_model,
                                                   mask=self.inputs.mask_file,
                                                   smoothing_fwhm=self.inputs.smoothing_kernel,
-                                                  standardize=1,
+                                                  standardize=True,
                                                   signal_scaling=0,
+                                                  period_cut=low_pass_period,
+                                                  drift_model='cosine',
                                                   verbose=1)
 
         # initialize dictionary to contain trial estimates (betas)

--- a/src/nibetaseries/workflows/base.py
+++ b/src/nibetaseries/workflows/base.py
@@ -18,7 +18,7 @@ from bids.grabbids import BIDSLayout
 
 
 def init_nibetaseries_participant_wf(atlas_img, atlas_lut, bids_dir,
-                                     derivatives_pipeline_dir, exclude_variant_label, high_pass, hrf_model, low_pass,
+                                     derivatives_pipeline_dir, exclude_variant_label, hrf_model, low_pass,
                                      output_dir, run_label, selected_confounds, session_label, smoothing_kernel,
                                      space_label, subject_list, task_label, variant_label, work_dir):
     """
@@ -38,8 +38,6 @@ def init_nibetaseries_participant_wf(atlas_img, atlas_lut, bids_dir,
             Root directory of the derivatives pipeline
         exclude_variant_label: str or None
             Exclude bold series containing this variant label
-        high_pass : float or None
-            High pass filter (Hz)
         hrf_model : str
             The model that represents the shape of the hemodynamic response function
         low_pass : float or None
@@ -96,7 +94,6 @@ def init_nibetaseries_participant_wf(atlas_img, atlas_lut, bids_dir,
             brainmask_list=brainmask_list,
             confound_tsv_list=confound_tsv_list,
             events_tsv_list=events_tsv_list,
-            high_pass=high_pass,
             hrf_model=hrf_model,
             low_pass=low_pass,
             name='single_subject' + subject_label + '_wf',
@@ -118,7 +115,7 @@ def init_nibetaseries_participant_wf(atlas_img, atlas_lut, bids_dir,
     return nibetaseries_participant_wf
 
 
-def init_single_subject_wf(atlas_img, atlas_lut, brainmask_list, confound_tsv_list, events_tsv_list, high_pass,
+def init_single_subject_wf(atlas_img, atlas_lut, brainmask_list, confound_tsv_list, events_tsv_list,
                            hrf_model, low_pass, name, output_dir, preproc_img_list, selected_confounds,
                            smoothing_kernel):
     """
@@ -134,7 +131,6 @@ def init_single_subject_wf(atlas_img, atlas_lut, brainmask_list, confound_tsv_li
             brainmask_list=[''],
             confound_tsv_list=[''],
             events_tsv_list=[''],
-            high_pass='',
             hrf_model='',
             low_pass='',
             name='subtest',
@@ -156,8 +152,6 @@ def init_single_subject_wf(atlas_img, atlas_lut, brainmask_list, confound_tsv_li
             list of confound tsvs (e.g. from FMRIPREP)
         events_tsv_list : list
             list of event tsvs
-        high_pass : float or None
-            high pass filter to apply to bold (in Hertz). Reminder - frequencies _higher_ than this number are kept.
         hrf_model : str
             hemodynamic response function used to model the data
         low_pass : float or None
@@ -219,7 +213,7 @@ def init_single_subject_wf(atlas_img, atlas_lut, brainmask_list, confound_tsv_li
                           name='output_node')
 
     # initialize the betaseries workflow
-    betaseries_wf = init_betaseries_wf(hrf_model=hrf_model, low_pass=low_pass, high_pass=high_pass,
+    betaseries_wf = init_betaseries_wf(hrf_model=hrf_model, low_pass=low_pass,
                                        selected_confounds=selected_confounds, smoothing_kernel=smoothing_kernel)
 
     # initialize the analysis workflow

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,8 @@ commands =
          {toxworkdir}/out \
          participant \
          -c WhiteMatter CSF \
-         -sm 6.0
+         -sm 6.0 \
+         -lp 0.01
 
 [testenv:clean]
 commands = coverage erase


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Fixes #15. <!-- (e.g. Fixes #58.) -->
This pull request will combine the temporal filtering step and beta series estimation step into one, so that all the relevant confounds will be accounted for simultaneously, instead of sequentially (which is bad)
## List of changes proposed in this PR (pull-request)
- remove the possibility of a high pass filter
    - this option isn't available in nistats, but the drift model should be able to care of low frequency noise
- embed `low_pass` filter option into the `nistats` interface

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
