### PR TITLE
[DOC] fix links in docs

### DIFF
--- a/docs/betaseries.rst
+++ b/docs/betaseries.rst
@@ -197,9 +197,9 @@ betaseries correlations
 
 Other Relevant Readings
 -----------------------
-- [Cisler2014]
-- [Gottlich2015]
-- [Abdulrahman2016]
+- [Cisler2014]_
+- [Gottlich2015]_
+- [Abdulrahman2016]_
 
 References
 ----------


### PR DESCRIPTION
## Summary
- some links in the docs (other relevant reading section) missed an underscore and hence hyperlinks were not generated

Fixes #110 

## List of changes proposed in this PR (pull-request)
- this PR adds the respective underscores