### PR TITLE
[FIX] add graphviz as dependency for building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ matrix:
     env:
       - TOXENV=check
   - name: "Building Docs"
+    before_install:
+    - sudo apt-get update
+    - sudo apt-get install -y graphviz  # https://github.com/nipy/nipype/issues/858
+    - python --version
+    - uname -a
+    - lsb_release -a
     env:
       - TOXENV=docs
     python: '3.5'  # match version from readthedocs


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
This fixes the [OSError on travis](https://travis-ci.org/HBClab/NiBetaSeries/jobs/468909891#L559)

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- adds `graphviz` as a dependency for building the documentation.