### PR TITLE
[FIX] remove redundant/irrelevant doc building options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,12 +46,7 @@ extlinks = {
     'pr': ('https://github.com/HBClab/NiBetaSeries/pull/%s', 'PR #'),
 }
 html_theme = "sphinx_rtd_theme"
-html_theme_options = {
-    'githuburl': 'https://github.com/HBClab/NiBetaSeries/'
-}
 
-html_use_smartypants = True
-html_split_index = False
 html_sidebars = {
    '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
 }


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #32 . <!-- (e.g. Fixes #58.) -->
the `githuburl` option came from `sphinx-py3doc-enhanced-theme`, but I am not using that theme anymore rendering the option useless.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- remove the `githuburl` option
- remove some `rtd` options that are the same as their defaults.