### PR TITLE
[FIX] remove .git from the binder url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ for links to render properly.
     :target: https://circleci.com/gh/HBClab/NiBetaSeries
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/HBClab/NiBetaSeries.git/binder?filepath=%2Fbinder%2Fplot_run_nibetaseries.ipynb
+    :target: https://mybinder.org/v2/gh/HBClab/NiBetaSeries/binder?filepath=%2Fbinder%2Fplot_run_nibetaseries.ipynb
 
 .. |version| image:: https://img.shields.io/pypi/v/nibetaseries.svg
     :alt: PyPI Package latest release

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -7,4 +7,4 @@ It will run Jupyter through your browser and you will not have
 to install any software (it may take a few seconds for the Binder session to
 launch).
 
-.. _Binder: https://mybinder.org/v2/gh/HBClab/NiBetaSeries.git/binder?filepath=%2Fbinder%2Fplot_run_nibetaseries.ipynb
+.. _Binder: https://mybinder.org/v2/gh/HBClab/NiBetaSeries/binder?filepath=%2Fbinder%2Fplot_run_nibetaseries.ipynb


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #166 . <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- removes .git from binder link as suggested by [this comment](https://github.com/jupyterhub/binder/issues/167#issuecomment-515752956)