### PR TITLE
[DOC] Fix documentation headers

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -94,15 +94,15 @@
       "type": "ProjectMember"
     },
     {
+      "name": "Trievel, Alec B.",
+      "affiliation": "Open source developer/contributor",
+      "type": "ProjectMember"
+    },
+    {
       "name": "Voss, Michelle",
       "affiliation": "Health, Brain, and Cognition Lab, University of Iowa",
       "orcid": "0000-0002-3706-7423",
       "type": "Supervisor"
-    },
-    {
-      "name": "Trievel, Alec B.",
-      "affiliation": "Open source developer/contributor",
-      "type": "ProjectMember"
     }
   ],
   "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -98,6 +98,11 @@
       "affiliation": "Health, Brain, and Cognition Lab, University of Iowa",
       "orcid": "0000-0002-3706-7423",
       "type": "Supervisor"
+    },
+    {
+      "name": "Trievel, Alec B.",
+      "affiliation": "Open source developer/contributor",
+      "type": "ProjectMember"
     }
   ],
   "keywords": [

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,8 +1,8 @@
 .. _nibetaseries_development_guide:
 
-##############################
+==============================
 NiBetaSeries Development Guide
-##############################
+==============================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/development/release_instructions.rst
+++ b/docs/development/release_instructions.rst
@@ -1,8 +1,8 @@
 .. _release_instructions:
 
-####################
+====================
 Release Instructions
-####################
+====================
 
 In order to create a release for NiBetaSeries, we must make sure the pre-conditions are
 met, and that we follow the release instructions.

--- a/docs/development/roadmap.rst
+++ b/docs/development/roadmap.rst
@@ -1,8 +1,8 @@
 .. _roadmap:
 
-#######
+=======
 Roadmap
-#######
+=======
 
 This page serves as a reference to the overall goals of NiBetaSeries development.
 


### PR DESCRIPTION
## Summary 
Replaced all instances of the `###` RST headers with a standard format: `===`

Fixes #232 

## List of changes proposed in this PR (pull-request)
* [x] Refactored `docs/development/index.rst` with new headers
* [x] Refactored `docs/development/release_instructions.rst` with new headers
* [x] Refactored ` docs/development/roadmap.rst` with new headers
* [x] Ran tests via `tox` command
* [x] Added name to `.zenodo.json` contributor file 