### PR TITLE
[ENH] allow regex for confound specification and impute derivatives

### DIFF
--- a/src/nibetaseries/cli/tests/test_run.py
+++ b/src/nibetaseries/cli/tests/test_run.py
@@ -64,7 +64,8 @@ def test_nibs(
             bids_dir,
             "fmriprep",
             out_dir,
-            "participant"]
+            "participant",
+            "-c", ".*derivative.*"]
     if fir_delays:
         args.append('--fir-delays')
         args.extend([str(d) for d in fir_delays])

--- a/src/nibetaseries/conftest.py
+++ b/src/nibetaseries/conftest.py
@@ -273,16 +273,42 @@ def sub_events(bids_dir, sub_metadata, preproc_file,
 def confounds_file(deriv_dir, preproc_file,
                    deriv_regressor_fname=deriv_regressor_fname):
     confounds_file = deriv_dir.ensure(deriv_regressor_fname)
+    confound_dict = {}
     tp = nib.load(str(preproc_file)).shape[-1]
     ix = np.arange(tp)
     # csf
-    csf = np.cos(2*np.pi*ix*(50/tp)) * 0.1
+    confound_dict['csf'] = np.cos(2*np.pi*ix*(50/tp)) * 0.1
     # white matter
-    wm = np.sin(2*np.pi*ix*(22/tp)) * 0.1
+    confound_dict['white_matter'] = np.sin(2*np.pi*ix*(22/tp)) * 0.1
     # framewise_displacement
-    fd = np.random.random_sample(tp)
-    fd[0] = np.nan
-    confounds_df = pd.DataFrame({'white_matter': wm, 'csf': csf, 'framewise_displacement': fd})
+    confound_dict['framewise_displacement'] = np.random.random_sample(tp)
+    confound_dict['framewise_displacement'][0] = np.nan
+    # motion outliers
+    for motion_outlier in range(0, 5):
+        mo_name = 'motion_outlier0{}'.format(motion_outlier)
+        confound_dict[mo_name] = np.zeros(tp)
+        confound_dict[mo_name][motion_outlier] = 1
+    # derivatives
+    derive1 = [
+        'csf_derivative1',
+        'csf_derivative1_power2',
+        'global_signal_derivative1_power2',
+        'trans_x_derivative1',
+        'trans_y_derivative1',
+        'trans_z_derivative1',
+        'trans_x_derivative1_power2',
+        'trans_y_derivative1_power2',
+        'trans_z_derivative1_power2',
+    ]
+    for d in derive1:
+        confound_dict[d] = np.random.random_sample(tp)
+        confound_dict[d][0] = np.nan
+
+    # transformations
+    for dir in ["trans_x", "trans_y", "trans_z"]:
+        confound_dict[dir] = np.random.random_sample(tp)
+
+    confounds_df = pd.DataFrame(confound_dict)
     confounds_df.to_csv(str(confounds_file), index=False, sep='\t', na_rep='n/a')
     return confounds_file
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #274. <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- allow regex expressions to be passed to `-c` argument
- test new functionality