### PR TITLE
[FIX] allow atlas arguments to be None

### DIFF
--- a/src/nibetaseries/cli/run.py
+++ b/src/nibetaseries/cli/run.py
@@ -230,12 +230,19 @@ def main():
                       'parameterize_dirs': False},
     })
 
+    # check if atlas img or atlas lut exist
+    if opts.atlas_img and opts.atlas_lut:
+        atlas_img = os.path.abspath(opts.atlas_img)
+        atlas_lut = os.path.abspath(opts.atlas_lut)
+    else:
+        atlas_img = atlas_lut = None
+
     # running participant level
     if opts.analysis_level == "participant":
         nibetaseries_participant_wf = init_nibetaseries_participant_wf(
             estimator=opts.estimator,
-            atlas_img=os.path.abspath(opts.atlas_img),
-            atlas_lut=os.path.abspath(opts.atlas_lut),
+            atlas_img=atlas_img,
+            atlas_lut=atlas_lut,
             bids_dir=bids_dir,
             database_path=opts.database_path,
             derivatives_pipeline_dir=derivatives_pipeline_dir,

--- a/src/nibetaseries/cli/tests/test_run.py
+++ b/src/nibetaseries/cli/tests/test_run.py
@@ -36,20 +36,18 @@ def test_conditional_arguments(monkeypatch):
         get_parser().parse_args(no_img)
 
 
-@pytest.mark.parametrize("estimator,fir_delays,hrf_model,part_label",
-                         [('lsa', None, 'spm', '01'),
-                          ('lss', None, 'spm', 'sub-01'),
-                          ('lss', [0, 1, 2, 3, 4], 'fir', None)])
+@pytest.mark.parametrize("use_atlas,estimator,fir_delays,hrf_model,part_label",
+                         [(True, 'lsa', None, 'spm', '01'),
+                          (False, 'lss', None, 'spm', 'sub-01'),
+                          (True, 'lss', [0, 1, 2, 3, 4], 'fir', None)])
 def test_nibs(
         bids_dir, deriv_dir, sub_fmriprep, sub_metadata, bold_file, preproc_file,
         sub_events, confounds_file, brainmask_file, atlas_file, atlas_lut,
-        estimator, fir_delays, hrf_model, monkeypatch, part_label):
+        estimator, fir_delays, hrf_model, monkeypatch, part_label, use_atlas):
     import sys
     bids_dir = str(bids_dir)
     out_dir = os.path.join(bids_dir, 'derivatives')
     args = ["nibs",
-            "-a", str(atlas_file),
-            "-l", str(atlas_lut),
             "-c", "white_matter", "csf",
             "--high-pass", "0.008",
             "--estimator", estimator,
@@ -66,6 +64,8 @@ def test_nibs(
             out_dir,
             "participant",
             "-c", ".*derivative.*"]
+    if use_atlas:
+        args.extend(["-a", str(atlas_file), "-l", str(atlas_lut)])
     if fir_delays:
         args.append('--fir-delays')
         args.extend([str(d) for d in fir_delays])


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #282. <!-- (e.g. Fixes #58.) -->
While the commandline does not complain about not specifying the arugments `-a` and `-l`, the arguments are not being treated correctly in `run.py`. This pull request should address that issue.
## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- handle case when `atlas_img` and `atlas_lut` are None
- add test to ensure desired functionality.
