### PR TITLE
fix singularity install instructions in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,7 +59,7 @@ Once Singularity is installed, you can pull the NiBetaSeries image via:
 
 ::
 
-  singularity build /path/to/image/nibetaseries-vX.Y.Z.simg docker://HBClab/nibetaseries:vX.Y.Z
+  singularity build /path/to/image/nibetaseries-vX.Y.Z.simg docker://hbclab/nibetaseries:vX.Y.Z
 
 Once the image is completely pulled, the containerized version of
 NiBetaSeries is evoked from the command line:


### PR DESCRIPTION

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary

The singularity install instructions in the docs contained a typo ("HBC" instead of "hbc") that prevented the image build. This should be fixed through this PR.

Fixes  #214.

## List of changes proposed in this PR (pull-request)
- [docs/installation.rst](https://github.com/HBClab/NiBetaSeries/blob/master/docs/installation.rst)