### PR TITLE
[ENH] add residuals to LSS/LSA interfaces

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     nipype ~= 1.4.2
     pybids ~= 0.9.3
     nibabel ~= 2.4.0
-    nistats == 0.0.1b1
+    nistats == 0.0.1b2
     nilearn ~= 0.4.2
     pandas ~= 0.24.0
     numpy


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #293 . <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- bumps nistats version to include residual retrieval
- adds residuals to interfaces
- adds more in depth testing of LSS/LSA outputs