### PR TITLE
[MAINT] update travis badge and pin sphinx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ for links to render properly.
 .. |joss| image:: https://joss.theoj.org/papers/10.21105/joss.01295/status.svg
    :target: https://doi.org/10.21105/joss.01295
 
-.. |travis| image:: https://travis-ci.org/HBClab/NiBetaSeries.svg?branch=master
+.. |travis| image:: https://travis-ci.com/HBClab/NiBetaSeries.svg?branch=master
     :alt: Travis-CI Build Status
-    :target: https://travis-ci.org/HBClab/NiBetaSeries
+    :target: https://travis-ci.com/HBClab/NiBetaSeries
 
 .. |codecov| image:: https://codecov.io/github/HBClab/NiBetaSeries/coverage.svg?branch=master
     :alt: Coverage Status

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ dev =
     codecov
     coverage
 doc = 
-    sphinx > 2
+    sphinx > 2,< 3
     sphinx_rtd_theme
     sphinx-argparse
     sphinx-gallery


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # None. <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
This updates the travis ci badge to point to it's .com variation since the .org variation is deprecated, and this pins sphinx, since they recently went through a major release.