### PR TITLE
[FIX] make the crashdump directory the same directory as outputs

### DIFF
--- a/src/nibetaseries/workflows/base.py
+++ b/src/nibetaseries/workflows/base.py
@@ -186,8 +186,9 @@ It is released under the [CC0]\
             smoothing_kernel=smoothing_kernel,
         )
 
+        # add nibetaseries to the output directory because of DerivativesDataSink class
         single_subject_wf.config['execution']['crashdump_dir'] = (
-            os.path.join(output_dir, "sub-" + subject_label, 'log')
+            os.path.join(output_dir, "nibetaseries", "sub-" + subject_label, 'log')
         )
 
         for node in single_subject_wf._get_all_nodes():


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a NiBetaSeries contributor and your name is not mentioned please modify .zenodo.json file.
2. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
3. Run `tox` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
This places the crashfiles into the output directory.

ref #319  <!-- (e.g. Fixes #58.) -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
